### PR TITLE
[api] avoid random crashes in test suite

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -996,7 +996,7 @@ class SourceController < ApplicationController
     project_name = params[:project]
     package_name = params[:package]
     file = params[:file]
-    if file.empty?
+    if file.blank?
 	return index_package
     end
     path = "/source/#{URI.escape(project_name)}/#{URI.escape(package_name)}/#{URI.escape(file)}"


### PR DESCRIPTION
Tempfile volleys are racy because the file is deleted at the time
the Tempfile object is garbage collected - which is basically random

(cherry picked from commit d6f9e55dcaa954eb7f1a556fb0d69dbdd5cef015)

The :encoding setting passed to Tempfile.new was dropped as that option
doesn't seem to exist on ruby-1.8 and it crashes.

[endlessm/eos-shell#6237]
