### PR TITLE
[backend] Support upstream source signature publishing

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -1092,7 +1092,7 @@ sub publish {
 	  $p = "$bin";
 	} elsif ($bin =~ /\.raw(:?\.install)?(:?\.sha256)?$/) {
 	  $p = "$bin";
-	} elsif ($bin =~ /\.tar\.(:?gz|bz2|xz)(:?\.sha256)?$/) {
+	} elsif ($bin =~ /\.tar\.(:?gz|bz2|xz)(:?\.asc)?(:?\.sha256)?$/) {
 	  $p = "$bin";
 	} elsif ($bin =~ /\.changes(:?\.sha256)?$/) {
 	  $p = "$arch/$bin";


### PR DESCRIPTION
Newer dpkg allows including a detached signature for the upstream
source tarball, e.g. .orig.tar.<ext>.asc. This file is referenced by the
dsc, so it needs to be included in the OBS publishing. Allow an optional
.asc suffix on published tarballs.

https://phabricator.endlessm.com/T13686
