### PR TITLE
Patch: [api] use rails tmp dir instead of system one

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -374,9 +374,9 @@ class ApplicationController < ActionController::Base
     # as the send_file function only references the path to it. So we keep it
     # for ourselves. And once the controller is garbage collected, it should
     # be fine to unlink the data
-    @volleyfile = Tempfile.new 'volley'
-    opts = { :url_based_filename => true }
-    
+    @volleyfile = Tempfile.new('volley', "#{Rails.root}/tmp", encoding: 'ascii-8bit')
+    opts = { url_based_filename: true }
+
     backend_http.request_get(path) do |res|
       opts[:status] = res.code
       opts[:type] = res['Content-Type']
@@ -394,7 +394,7 @@ class ApplicationController < ActionController::Base
 
   hide_action :download_request
   def download_request
-    file = Tempfile.new 'volley'
+    file = Tempfile.new('volley', "#{Rails.root}/tmp", encoding: 'ascii-8bit')
     b = request.body
     buffer = String.new
     while b.read(40960, buffer)


### PR DESCRIPTION
We do use the rails environemt tmp dir only in some cases so far.
This might create problems when the system tmp dir has way less space
than the one supposed to be used for the rails app.

Partially backported due to files being moved in later versions

https://phabricator.endlessm.com/T6237