### PR TITLE
Stop using upload icon for the download file button

### DIFF
--- a/src/webui/app/views/package/_files_view.html.erb
+++ b/src/webui/app/views/package/_files_view.html.erb
@@ -28,7 +28,7 @@
             <td><span class="hidden"><%= file[:mtime] %></span><%= fuzzy_time_string( Time.at(file[:mtime].to_i).to_s ) %></td>
             <!-- limit download for anonymous user to avoid getting killed by crawlers -->
             <td><%= if @user or file[:size].to_i < ( 4 * 1024 * 1024 )
-                      link_to image_tag('icons/page_white_get.png', :alt => "Download", :title => "Download File"), file_url( @project, @package, file[:name], file[:srcmd5] )
+                      link_to image_tag('icons/page_white_put.png', :alt => "Download", :title => "Download File"), file_url( @project, @package, file[:name], file[:srcmd5] )
                     end %>
               <% unless file[:name].match(/^_service:/) %>
                 <% if @package.can_edit?( session[:login] ) %>


### PR DESCRIPTION
Srdjan found the icon pack and the right file name to use. Seems the icon pack has the icons backwards... obviously "get" should be a download button and "put" should be an upload button, but they got this wrong.