### PR TITLE
Add xz-utils dependency to obs-worker

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,7 @@ Architecture: any
 Depends:
  ${misc:Depends}, ${shlibs:Depends}, apt-utils, binutils, bsdtar, curl,
  debootstrap, dpkg (>= 1.16.5), libtimedate-perl, libxml-parser-perl,
- libxml-simple-perl, lzma, rpm, screen, slptool
+ libxml-simple-perl, lzma, rpm, screen, slptool, xz-utils
 Description: Open Build Service (build host component)
  This is the obs build host, to be installed on each machine building
  packages in this obs installation.  Install it alongside obs-server to


### PR DESCRIPTION
The fetched obs-build code will use unxz to decompress control.tar.xz
archives in deb files. Ensure this is available on the worker by
depending on xz-utils.