### PR TITLE
[backend] add code to filter workers which don't allow personality change

### DIFF
--- a/src/backend/BSCando.pm
+++ b/src/backend/BSCando.pm
@@ -31,12 +31,13 @@ package BSCando;
 #FIXME 3.0: obsolete the not exiting arm architectures
 
 our %cando = (
-  'aarch64' => [ 'aarch64_ilp32', 'aarch64', 'armv8l' ], # armv8l is aarch32 (32-bit mode of aarch64), not a full subset of armv7l
-  'aarch64_ilp32' => [ 'aarch64_ilp32', 'aarch64', 'armv8l' ],
+  # aarch64_ilp32: is just a software architecure convention
+  'aarch64' => [ 'aarch64', 'aarch64_ilp32', 'armv8l:linux32', 'armv7l:linux32', 'armv7hl:linux32', 'armv6l:linux32', 'armv6hl:linux32' ],
+  'aarch64_ilp32' => [ 'aarch64_ilp32', 'aarch64' ],
   'armv4l'  => [ 'armv4l'                                                                                                 ],
   'armv5l'  => [ 'armv4l', 'armv5l'                    , 'armv5el'                                                        ],
   'armv6l'  => [ 'armv4l', 'armv5l', 'armv6l'          , 'armv5el', 'armv6el'                                             ],
-  'armv7l'  => [ 'armv4l', 'armv5l', 'armv6l', 'armv7l', 'armv5el', 'armv6el', 'armv6hl', 'armv7el', 'armv7hl', 'armv8el' ], # this armv8el is just for MeeGo, it does not exist for real
+  'armv7l'  => [ 'armv4l', 'armv5l', 'armv6l', 'armv7l', 'armv5el', 'armv6el', 'armv6hl', 'armv7el', 'armv7hl', 'armv8el' ], # armv8el is invented by MeeGo, it does not exist for real
   'armv8l'  => [ 'armv8l' ],
 
   'sh4'     => [ 'sh4' ],

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -733,6 +733,7 @@ our $worker = [
         ],
         'processors',
         'jobs',         # compat for OBS 2.8 worker
+        'nativeonly',   # don't allow usage via the helper script
 	'memory',	# in MBytes
 	'swap',		# in MBytes
 	'disk',		# in MBytes

--- a/src/backend/bs_dispatch
+++ b/src/backend/bs_dispatch
@@ -1327,6 +1327,12 @@ while (1) {
 	if ($BSConfig::dispatch_constraint) {
 	  next if !$BSConfig::dispatch_constraint->($info, $workerinfo{$idle});
 	}
+        # a helper is needed for personality change?
+        my $helper;
+        /^\Q$arch\E:(.*)$/ && ($helper = $1) for @{$BSCando::cando{$harch}};
+        if ($helper && $workerinfo{$idle} && $workerinfo{$idle}->{hardware} && $workerinfo{$idle}->{hardware}->{nativeonly}) {
+           next; # worker is not supporting the needed personality change
+        }
 	if ($constraints) {
 	  my $ora = oracle($workerinfo{$idle}, $constraints);
 	  next unless defined($ora) && $ora > 0;

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -653,8 +653,16 @@ if (open(FILE, "<", "/proc/cpuinfo")) {
     if (/^processor/s) {
       $hw->{'processors'} = $hw->{'processors'} + 1;
     } elsif (/^flags\s*:\s(.*)$/) {
+      # classic ix86 and x86_64
       my @cpuflags = split(' ', $1);
       $hw->{'cpu'}->{'flag'} = \@cpuflags;
+    } elsif (/^Features\s*:\s(.*)$/) {
+      # aarch64
+      my @cpuflags = split(' ', $1);
+      $hw->{'cpu'}->{'flag'} = \@cpuflags;
+    } elsif (/^CPU implementer\s*:\s0x43/) {
+      # aarch64 special case: does not support armvXl instruction set
+      $hw->{'cpu'}->{'nativeonly'} = {};
     } elsif (/^cpu\s*:\sPOWER8/) {
       # PowerPC kernel does not provide any flags, but we need to be able
       # to distinguish between power7 and 8 at least

--- a/src/backend/testdata/workerinfo/large
+++ b/src/backend/testdata/workerinfo/large
@@ -14,6 +14,7 @@
     <cpu>
       <flag>mmx</flag>
     </cpu>
+    <nativeonly/>
     <processors>32</processors>
     <memory>6400</memory>
     <swap>51200</swap>


### PR DESCRIPTION
One special kind of aarch64 cpu workers are such an example

(cherry picked from commit 03bfd8d0ffce686f560582314f08cba3c5bdc5d4)

This allows armv7hl to be run via `linux32` from an armv8 host when it has 32 bit compat mode (if `CPU implementer` does not say `0x43` in `/proc/cpuinfo` according to the diff). This is a backport from 2.8.0.

https://phabricator.endlessm.com/T24821