### PR TITLE
Make request migration robust

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -91,12 +91,15 @@ class BsRequest < ActiveRecord::Base
     unless self.creator
       errors.add(:creator, 'No creator defined')
     end
-    user = User.get_by_login self.creator
-    unless user
-      errors.add(:creator, "Invalid creator specified #{self.creator}")
-    end
-    unless user.is_active?
-      errors.add(:creator, "Login #{user.login} is not an active user")
+    # Allow admins to create requests for deleted or inactive users
+    unless User.current.is_admin?
+      user = User.get_by_login self.creator
+      unless user
+        errors.add(:creator, "Invalid creator specified #{self.creator}")
+      end
+      unless user.is_active?
+        errors.add(:creator, "Login #{user.login} is not an active user")
+      end
     end
   end
 

--- a/src/api/lib/workers/import_requests.rb
+++ b/src/api/lib/workers/import_requests.rb
@@ -15,11 +15,15 @@ class ImportRequestsDelayedJob
         next
       end
       r = BsRequest.new_from_xml xml
-      if r.save
-        Rails.logger.info "Request ##{lastrq} imported"
-      else
-        Rails.logger.error "Request ##{lastrq} could not be saved:\n%s" \
-                           % r.errors.full_messages.join("\n")
+      begin
+        if r.save
+          Rails.logger.info "Request ##{lastrq} imported"
+        else
+          Rails.logger.error "Request ##{lastrq} could not be saved:\n%s" \
+                             % r.errors.full_messages.join("\n")
+        end
+      rescue ActiveRecord::RecordNotUnique
+        Rails.logger.debug "Request ##{lastrq} already imported"
       end
       lastrq -= 1
     end

--- a/src/api/lib/workers/import_requests.rb
+++ b/src/api/lib/workers/import_requests.rb
@@ -9,13 +9,15 @@ class ImportRequestsDelayedJob
     while lastrq > 0
       begin
         xml = Suse::Backend.get( "/request/#{lastrq}" ).body
-      rescue ActiveXML::Transport::Error
+      rescue ActiveXML::Transport::Error => err
+        Rails.logger.error "Request ##{lastrq} could not be retrieved:\n#{err}"
         lastrq -= 1
         next
       end
       r = BsRequest.new_from_xml xml
       unless r.save
-        puts "Request ##{lastrq}:", r.errors.full_messages.join("\n")
+        Rails.logger.error "Request ##{lastrq} could not be saved:\n%s" \
+                           % r.errors.full_messages.join("\n")
       end
       lastrq -= 1
     end

--- a/src/api/lib/workers/import_requests.rb
+++ b/src/api/lib/workers/import_requests.rb
@@ -15,7 +15,9 @@ class ImportRequestsDelayedJob
         next
       end
       r = BsRequest.new_from_xml xml
-      unless r.save
+      if r.save
+        Rails.logger.info "Request ##{lastrq} imported"
+      else
         Rails.logger.error "Request ##{lastrq} could not be saved:\n%s" \
                            % r.errors.full_messages.join("\n")
       end


### PR DESCRIPTION
This is a backport of openSUSE/open-build-service#7125. It allows the old XML on disk requests to be migrated to a database format when the request creator users have been deleted or are locked. It also catches when the requests have already been imported to allow the migration to be restarted if necessary.

https://phabricator.endlessm.com/T23473