### PR TITLE
[dist] obsworker cleanup running screen on stop

### DIFF
--- a/debian/obs-worker.obsworker.init
+++ b/debian/obs-worker.obsworker.init
@@ -216,6 +216,7 @@ case "$1" in
         rm -rf "$workerdir"
         mkdir -p "$workerbootdir"
         echo "zombie on"       > $screenrc
+        echo "defscrollback 10000" >> $screenrc
         echo 'caption always "%3n %t%? [%h]%?"' >> $screenrc
 
         if [ 0"$OBS_WORKER_INSTANCES" -gt 0 ]; then
@@ -337,7 +338,7 @@ case "$1" in
 	    mkdir -p $workerdir/$I
         done
         pushd "$workerbootdir" > /dev/null
-        screen -m -d -c $screenrc
+        screen -S obsworker -m -d -c $screenrc
         popd > /dev/null
     ;;
     stop)
@@ -353,6 +354,7 @@ case "$1" in
         killall bs_worker 2>/dev/null
         sleep 2
         killall -s 9 bs_worker 2>/dev/null
+        screen -S obsworker -X quit
     ;;
     restart)
         ## If first returns OK call the second, if first or


### PR DESCRIPTION
This is a backport of commit f9303f846ebc6703cbf0a980427f6e8ac19e4415
from upstream's obsworker init script applied to debian's copy. Without
it, screen is never killed and systemd regards the service as failed
when it's stopped because there are still processes running.