### PR TITLE
Update obs-build submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/backend/build"]
 	path = src/backend/build
-	url = git://github.com/openSUSE/obs-build.git
+	url = git@github.com:openSUSE/obs-build.git


### PR DESCRIPTION
git:// protocol is not supported on github since 2022.
https://github.blog/2021-09-01-improving-git-protocol-security-github/
